### PR TITLE
Add feature selection and PCA cluster plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,16 @@ Example usage:
 python evaluate.py --model path/to/model.pkl --data path/to/test.csv --task classification --target label
 ```
 
-The script writes metrics to `evaluation_output/metrics.json` and saves SHAP plots in the same directory.
+For clustering tasks you can optionally specify which feature columns to use
+for evaluation and PCA cluster visualisation. If omitted, all numeric columns
+are used automatically.
+
+```bash
+python evaluate.py --model path/to/model.pkl --data path/to/test.csv --task clustering --features spend sessions
+```
+
+The script writes metrics to `evaluation_output/metrics.json` and saves SHAP
+plots (and clustering plots when applicable) in the same directory.
 
 ## build_database.py
 


### PR DESCRIPTION
## Summary
- Add optional `--features` argument to `evaluate.py` and infer numeric columns when omitted
- Generate PCA cluster visualization using selected features
- Document new feature selection workflow with clustering example

## Testing
- `python -m py_compile evaluate.py`
- `python evaluate.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c5af2b8ccc832da9d795b454f113ab