### PR TITLE
Add synthetic data generation and model training scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
 # Apponomics
 
-Utility scripts for working with mobile app usage data. The project currently
-includes placeholders for data generation and model training as well as a
+Utility scripts for working with mobile app usage data. The project now
+provides a basic data generation and model training pipeline alongside a
 functional evaluation script and Streamlit demo app.
 
 ## Scripts
 
-- `scripts/generate_data.py` – **TODO:** implement data generation logic for
-  creating training datasets.
-- `scripts/train.py` – **TODO:** implement model training routine.
+- `scripts/generate_data.py` – create synthetic datasets for experimentation.
+- `scripts/train.py` – train classification, regression or clustering models.
 - `scripts/evaluate.py` – evaluate a serialized model on a dataset and output
   metrics, SHAP plots, and optional clustering visuals.
+
+Example usage for data generation and training:
+
+```bash
+python scripts/generate_data.py --rows 1000 --output data.csv
+python scripts/train.py --data data.csv --task classification --target churn --model model.pkl
+```
 
 Example usage for the evaluation script:
 

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -165,7 +165,7 @@ def main():
     if args.task in ("classification", "regression") and y is None:
         raise ValueError("Target column must be provided for supervised tasks")
 
-    data_for_eval = X[features] if args.task == "clustering" else X
+    data_for_eval = X[features]
 
     if args.task == "classification":
         metrics = evaluate_classification(model, data_for_eval, y)

--- a/scripts/generate_data.py
+++ b/scripts/generate_data.py
@@ -1,12 +1,67 @@
-"""Placeholder for data generation script.
+"""Generate a synthetic dataset for training models.
 
-TODO: Implement data generation logic for training models.
+The script produces a CSV file with user spend, session counts,
+application tier and churn labels.  It is intentionally simple but
+sufficient for demonstrating the training and evaluation pipeline.
 """
 
+from __future__ import annotations
 
-def main():
-    raise NotImplementedError("TODO: implement data generation")
+import argparse
+from typing import Any
+
+import numpy as np
+import pandas as pd
 
 
-if __name__ == "__main__":
+def generate(rows: int, seed: int) -> pd.DataFrame:
+    """Create a random dataset.
+
+    Parameters
+    ----------
+    rows: int
+        Number of samples to generate.
+    seed: int
+        Seed for the pseudo-random number generator.
+    """
+
+    rng = np.random.default_rng(seed)
+
+    spend = rng.gamma(shape=2.0, scale=50.0, size=rows)
+    sessions = rng.poisson(lam=5, size=rows)
+
+    tier = np.where(
+        spend >= 500,
+        "premium",
+        np.where(spend >= 100, "standard", "free"),
+    )
+
+    churn_logit = 2.0 - 0.003 * spend - 0.3 * sessions
+    churn_prob = 1.0 / (1.0 + np.exp(-churn_logit))
+    churn = rng.binomial(1, np.clip(churn_prob, 0, 1))
+
+    df = pd.DataFrame(
+        {
+            "spend": spend.round(2),
+            "sessions": sessions,
+            "tier": tier,
+            "churn": churn,
+        }
+    )
+    return df
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Generate synthetic training data")
+    parser.add_argument("--rows", type=int, default=1000, help="Number of rows to generate")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument("--output", default="synthetic_data.csv", help="Output CSV file")
+    args = parser.parse_args(argv)
+
+    df = generate(args.rows, args.seed)
+    df.to_csv(args.output, index=False)
+    print(f"Saved {len(df)} rows to {args.output}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
     main()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,12 +1,67 @@
-"""Placeholder for model training script.
+"""Train basic machine learning models for the Apponomics dataset."""
 
-TODO: Implement training routine for machine learning models.
-"""
+from __future__ import annotations
+
+import argparse
+from typing import Iterable, Tuple
+
+import joblib
+import pandas as pd
+from sklearn.cluster import KMeans
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
 
-def main():
-    raise NotImplementedError("TODO: implement training")
+def load_dataset(
+    path: str,
+    target: str | None,
+    feature_cols: Iterable[str] | None,
+) -> Tuple[pd.DataFrame, pd.Series | None]:
+    """Load features and optional target column from CSV."""
+    df = pd.read_csv(path)
+
+    if feature_cols is None:
+        feature_cols = df.select_dtypes(include="number").columns.tolist()
+        if target and target in feature_cols:
+            feature_cols.remove(target)
+    X = df[list(feature_cols)]
+    y = df[target] if target else None
+    return X, y
 
 
-if __name__ == "__main__":
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Train a machine learning model")
+    parser.add_argument("--data", required=True, help="Path to CSV training data")
+    parser.add_argument(
+        "--task",
+        required=True,
+        choices=["classification", "regression", "clustering"],
+        help="Type of model to train",
+    )
+    parser.add_argument("--target", help="Target column for supervised tasks")
+    parser.add_argument("--model", required=True, help="Where to save the trained model")
+    parser.add_argument("--features", nargs="+", help="Optional list of feature columns to use")
+    parser.add_argument("--clusters", type=int, default=3, help="Number of clusters for clustering")
+    args = parser.parse_args(argv)
+
+    X, y = load_dataset(args.data, args.target, args.features)
+
+    if args.task == "classification":
+        if y is None:
+            raise ValueError("Target column required for classification")
+        model = RandomForestClassifier(random_state=42)
+        model.fit(X, y)
+    elif args.task == "regression":
+        if y is None:
+            raise ValueError("Target column required for regression")
+        model = RandomForestRegressor(random_state=42)
+        model.fit(X, y)
+    else:  # clustering
+        model = KMeans(n_clusters=args.clusters, random_state=42)
+        model.fit(X)
+
+    joblib.dump(model, args.model)
+    print(f"Trained {args.task} model saved to {args.model}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
     main()


### PR DESCRIPTION
## Summary
- implement synthetic dataset generator
- add training utility supporting classification, regression and clustering
- allow evaluation script to select numeric feature columns
- update README with usage examples

## Testing
- `python -m py_compile scripts/generate_data.py scripts/train.py scripts/evaluate.py`
- `python scripts/generate_data.py --help`
- `python scripts/train.py --help`
- `python scripts.generation_data.py --rows 50 --output temp_data.csv`
- `python scripts/train.py --data temp_data.csv --task classification --target churn --model temp_model.pkl`
- `python scripts/evaluate.py --model temp_model.pkl --data temp_data.csv --task classification --target churn --features spend sessions`


------
https://chatgpt.com/codex/tasks/task_e_68c5b677796c832db3d130e0813228de